### PR TITLE
fix(pricing): DeepSeek peak windows only apply on weekdays

### DIFF
--- a/cli/src/runtime/open-cowork-worker-runtime.ts
+++ b/cli/src/runtime/open-cowork-worker-runtime.ts
@@ -333,6 +333,7 @@ const DEFAULT_PEAK_HOURS_UTC = [
   { startHour: 6, endHour: 10 }
 ] as const
 
+/** Mirrors `isPeakPricingHour` in `src/renderer/src/lib/model-pricing.ts`. */
 function isPeakPricingHour(model: JsonRecord | null, at = new Date()): boolean {
   const schedule = model && isRecord(model.pricingSchedule) ? model.pricingSchedule : null
   const rawWindows = schedule && Array.isArray(schedule.peakHoursUtc) ? schedule.peakHoursUtc : null
@@ -349,7 +350,36 @@ function isPeakPricingHour(model: JsonRecord | null, at = new Date()): boolean {
           .filter((window): window is { startHour: number; endHour: number } => window !== null)
       : DEFAULT_PEAK_HOURS_UTC
   const hour = at.getUTCHours()
-  return windows.some((window) => hour >= window.startHour && hour < window.endHour)
+  if (!windows.some((window) => hour >= window.startHour && hour < window.endHour)) return false
+  const days = usablePeakDays(schedule)
+  if (days.length === 0) return true
+  return days.includes(isoWeekdayAt(at, peakDayOffsetHours(schedule)))
+}
+
+/**
+ * One unusable entry drops the whole restriction rather than just that entry: dropping
+ * entries would narrow the peak days and discount a request the vendor charges full
+ * rate for. The schedule arrives here as persisted JSON, so every field is re-checked.
+ */
+function usablePeakDays(schedule: JsonRecord | null): number[] {
+  const days = schedule && Array.isArray(schedule.peakDaysIso) ? schedule.peakDaysIso : null
+  if (!days || days.length === 0) return []
+  const usable = days.every(
+    (day) => Number.isInteger(day) && (day as number) >= 1 && (day as number) <= 7
+  )
+  return usable ? (days as number[]) : []
+}
+
+function peakDayOffsetHours(schedule: JsonRecord | null): number {
+  const offset = schedule ? schedule.peakDaysUtcOffset : null
+  if (!Number.isInteger(offset as number) || Math.abs(offset as number) > 14) return 0
+  return offset as number
+}
+
+/** ISO weekday (1 = Monday … 7 = Sunday) of `at` on a clock `offsetHours` from UTC. */
+function isoWeekdayAt(at: Date, offsetHours: number): number {
+  const day = new Date(at.getTime() + offsetHours * 3_600_000).getUTCDay()
+  return day === 0 ? 7 : day
 }
 
 interface ModelPrices {

--- a/scripts/test/model-pricing-tiers.test.ts
+++ b/scripts/test/model-pricing-tiers.test.ts
@@ -3,12 +3,13 @@ import test from 'node:test'
 import {
   DEEPSEEK_PRICING_SCHEDULE,
   hasTieredPricing,
+  isPeakPricingHour,
   normalizePricingTiers,
   resolveActivePricingTierFloor,
   resolveModelPricingBrackets,
   resolveModelPrices
 } from '../../src/renderer/src/lib/model-pricing.ts'
-import type { AIModelConfig } from '../../src/renderer/src/lib/api/types.ts'
+import type { AIModelConfig, ModelPricingSchedule } from '../../src/renderer/src/lib/api/types.ts'
 
 const tieredModel: AIModelConfig = {
   id: 'MiniMax-M3',
@@ -116,4 +117,98 @@ test('brackets describe the whole ladder for display', () => {
   )
   // Untiered models have no ladder to show.
   assert.deepEqual(resolveModelPricingBrackets({ ...tieredModel, pricingTiers: undefined }), [])
+})
+
+// 2026-01-01 is a Thursday, so 01-02 is Friday, 01-03 Saturday, 01-04 Sunday and
+// 01-05 Monday -- on UTC. Beijing is eight hours ahead, so from 16:00 UTC onwards
+// the two calendars are on different days, and that is where the tests below bite.
+const at = (iso: string): Date => new Date(iso)
+
+/**
+ * A synthetic 15:00-20:00 UTC window. DeepSeek's real windows (01-04, 06-10) both sit
+ * before 16:00 UTC, where the UTC and Beijing dates still agree -- so no test written
+ * against the real windows can tell "read the day in UTC" apart from "read it in
+ * Beijing". This card straddles 16:00 UTC, which is the only place the two differ.
+ */
+const lateWindow: ModelPricingSchedule = {
+  peakHoursUtc: [{ startHour: 15, endHour: 20 }],
+  peakDaysIso: [1, 2, 3, 4, 5],
+  peakDaysUtcOffset: 8
+}
+
+test('the weekend is off-peak even inside a peak window', () => {
+  // 02:00 UTC is inside DeepSeek's first window on every one of these days.
+  assert.equal(isPeakPricingHour(at('2026-01-01T02:00:00Z'), DEEPSEEK_PRICING_SCHEDULE), true)
+  assert.equal(isPeakPricingHour(at('2026-01-03T02:00:00Z'), DEEPSEEK_PRICING_SCHEDULE), false)
+  assert.equal(isPeakPricingHour(at('2026-01-04T02:00:00Z'), DEEPSEEK_PRICING_SCHEDULE), false)
+  assert.equal(isPeakPricingHour(at('2026-01-05T02:00:00Z'), DEEPSEEK_PRICING_SCHEDULE), true)
+  // Outside every window the day never gets a say.
+  assert.equal(isPeakPricingHour(at('2026-01-01T20:00:00Z'), DEEPSEEK_PRICING_SCHEDULE), false)
+})
+
+test('a schedule with no peak days is billed on every day of the week', () => {
+  const everyDay: ModelPricingSchedule = { peakHoursUtc: [{ startHour: 1, endHour: 4 }] }
+  assert.equal(isPeakPricingHour(at('2026-01-03T02:00:00Z'), everyDay), true)
+  assert.equal(isPeakPricingHour(at('2026-01-03T02:00:00Z'), null), true)
+})
+
+test('the peak day is read on the vendor clock, not on UTC', () => {
+  // Still Friday in Beijing, and already Saturday one minute later.
+  assert.equal(isPeakPricingHour(at('2026-01-02T15:59:00Z'), lateWindow), true)
+  assert.equal(isPeakPricingHour(at('2026-01-02T16:00:00Z'), lateWindow), false)
+  // Sunday in UTC both times, but the second one is Monday in Beijing.
+  assert.equal(isPeakPricingHour(at('2026-01-04T15:59:00Z'), lateWindow), false)
+  assert.equal(isPeakPricingHour(at('2026-01-04T16:00:00Z'), lateWindow), true)
+})
+
+test('peak days with no offset are counted in UTC', () => {
+  const utcDays: ModelPricingSchedule = { ...lateWindow, peakDaysUtcOffset: undefined }
+  assert.equal(isPeakPricingHour(at('2026-01-02T16:00:00Z'), utcDays), true)
+  assert.equal(isPeakPricingHour(at('2026-01-04T16:00:00Z'), utcDays), false)
+})
+
+test('an unreadable day list bills peak rather than inventing a discount', () => {
+  // Saturday 02:00 UTC: with a usable weekday list this is off-peak, so anything that
+  // still reads peak here proves the restriction was dropped whole, not trimmed.
+  // The mixed lists matter most: dropping just the bad entry would leave [1..5]
+  // standing, which reads as a clean weekday rule and quietly discounts the Saturday
+  // the card was trying to charge for. One bad entry has to take the list with it.
+  for (const days of [[], [0], [8], [1.5], [true], ['1'], 5, null, { 1: true },
+                      [1, 2, 3, 4, 5, '6'], [1, 2, 3, 4, 5, 6.5], [6, 0]]) {
+    const schedule = { ...DEEPSEEK_PRICING_SCHEDULE, peakDaysIso: days } as ModelPricingSchedule
+    const label = `days=${JSON.stringify(days)}`
+    assert.equal(isPeakPricingHour(at('2026-01-03T02:00:00Z'), schedule), true, label)
+  }
+  // A list that is merely unsorted or partial is perfectly usable.
+  const weekendOnly = { ...DEEPSEEK_PRICING_SCHEDULE, peakDaysIso: [7, 6] }
+  assert.equal(isPeakPricingHour(at('2026-01-03T02:00:00Z'), weekendOnly), true)
+  assert.equal(isPeakPricingHour(at('2026-01-05T02:00:00Z'), weekendOnly), false)
+})
+
+test('an unreadable offset falls back to counting the day in UTC', () => {
+  for (const offset of ['8', 8.5, 99, Number.NaN, null]) {
+    const schedule = { ...lateWindow, peakDaysUtcOffset: offset } as ModelPricingSchedule
+    // Friday in UTC, Saturday in Beijing: reading UTC is the answer that charges peak.
+    assert.equal(isPeakPricingHour(at('2026-01-02T16:00:00Z'), schedule), true, `offset=${offset}`)
+  }
+})
+
+test('a weekend request resolves to the off-peak rates end to end', () => {
+  const model: AIModelConfig = {
+    id: 'deepseek-v4-pro',
+    name: 'DeepSeek V4 Pro',
+    enabled: true,
+    inputPrice: 0.66,
+    outputPrice: 1.98,
+    offPeakInputPrice: 0.22,
+    offPeakOutputPrice: 0.66,
+    pricingSchedule: DEEPSEEK_PRICING_SCHEDULE
+  }
+  const weekday = resolveModelPrices(model, at('2026-01-01T02:00:00Z'))
+  const weekend = resolveModelPrices(model, at('2026-01-03T02:00:00Z'))
+  assert.equal(weekday.isPeak, true)
+  assert.equal(weekday.inputPrice, 0.66)
+  assert.equal(weekend.isPeak, false)
+  assert.equal(weekend.inputPrice, 0.22)
+  assert.equal(weekend.outputPrice, 0.66)
 })

--- a/src/renderer/src/lib/api/types.ts
+++ b/src/renderer/src/lib/api/types.ts
@@ -575,6 +575,18 @@ export interface ModelPeakHourWindow {
 
 export interface ModelPricingSchedule {
   peakHoursUtc: ModelPeakHourWindow[]
+  /**
+   * ISO weekdays (1 = Monday … 7 = Sunday) the windows apply on. Omit for every day.
+   * DeepSeek restricts its peak windows to weekdays; a card that leaves this out is
+   * billed at peak whenever the hour matches, which is what we do today.
+   */
+  peakDaysIso?: number[]
+  /**
+   * Hour offset of the clock `peakDaysIso` is counted on. Omit to count the day in
+   * UTC. DeepSeek states its weekday rule in Beijing time, so its card sets 8: the
+   * hours stay UTC, only the calendar date shifts.
+   */
+  peakDaysUtcOffset?: number
 }
 
 /**

--- a/src/renderer/src/lib/model-pricing.ts
+++ b/src/renderer/src/lib/model-pricing.ts
@@ -6,8 +6,19 @@ export const DEEPSEEK_PEAK_HOURS_UTC: ModelPricingSchedule['peakHoursUtc'] = [
   { startHour: 6, endHour: 10 }
 ]
 
+/**
+ * DeepSeek charges peak on weekdays only, and it counts the weekday on its own clock
+ * (Beijing, UTC+8) rather than on UTC. The two calendars disagree for 16:00–24:00 UTC,
+ * which is outside both windows above, so with today's windows the distinction never
+ * changes a bill -- it only starts mattering the day a window moves past 16:00 UTC.
+ */
+export const DEEPSEEK_PEAK_DAYS_ISO = [1, 2, 3, 4, 5]
+export const DEEPSEEK_PEAK_DAYS_UTC_OFFSET = 8
+
 export const DEEPSEEK_PRICING_SCHEDULE: ModelPricingSchedule = {
-  peakHoursUtc: DEEPSEEK_PEAK_HOURS_UTC
+  peakHoursUtc: DEEPSEEK_PEAK_HOURS_UTC,
+  peakDaysIso: DEEPSEEK_PEAK_DAYS_ISO,
+  peakDaysUtcOffset: DEEPSEEK_PEAK_DAYS_UTC_OFFSET
 }
 
 export interface ResolvedModelPrices {
@@ -54,13 +65,45 @@ export function formatPeakHoursUtc(schedule?: ModelPricingSchedule | null): stri
     .join(', ')
 }
 
+/**
+ * Whether `at` is billed at the peak rate: the UTC hour is inside a window, and -- if
+ * the schedule restricts them -- the day is one of the peak days. A schedule with no
+ * `peakDaysIso` keeps today's behaviour and bills peak on every day of the week.
+ */
 export function isPeakPricingHour(
   at: Date = new Date(),
   schedule?: ModelPricingSchedule | null
 ): boolean {
   const windows = schedule?.peakHoursUtc?.length ? schedule.peakHoursUtc : DEEPSEEK_PEAK_HOURS_UTC
   const hour = at.getUTCHours()
-  return windows.some((window) => hour >= window.startHour && hour < window.endHour)
+  if (!windows.some((window) => hour >= window.startHour && hour < window.endHour)) return false
+  const days = usablePeakDays(schedule)
+  if (days.length === 0) return true
+  return days.includes(isoWeekdayAt(at, peakDayOffsetHours(schedule)))
+}
+
+/**
+ * One unusable entry drops the whole restriction rather than just that entry. Dropping
+ * entries would narrow the peak days and hand out a discount the vendor never gave;
+ * dropping the restriction only ever charges the rate we already charge today.
+ */
+function usablePeakDays(schedule?: ModelPricingSchedule | null): number[] {
+  const days = schedule?.peakDaysIso
+  if (!Array.isArray(days) || days.length === 0) return []
+  const usable = days.every((day) => Number.isInteger(day) && day >= 1 && day <= 7)
+  return usable ? days : []
+}
+
+function peakDayOffsetHours(schedule?: ModelPricingSchedule | null): number {
+  const offset = schedule?.peakDaysUtcOffset
+  if (!Number.isInteger(offset as number) || Math.abs(offset as number) > 14) return 0
+  return offset as number
+}
+
+/** ISO weekday (1 = Monday … 7 = Sunday) of `at` on a clock `offsetHours` from UTC. */
+function isoWeekdayAt(at: Date, offsetHours: number): number {
+  const day = new Date(at.getTime() + offsetHours * 3_600_000).getUTCDay()
+  return day === 0 ? 7 : day
 }
 
 export function hasTieredPricing(model: AIModelConfig | null | undefined): boolean {


### PR DESCRIPTION
## What's wrong

`isPeakPricingHour` decides peak vs off-peak from `at.getUTCHours()` alone. DeepSeek's peak windows only apply **on weekdays** — a request at 02:00 UTC on a Saturday is off-peak, but OpenCowork bills it at the peak rate. On DeepSeek V4 Pro that's $0.66 / $1.98 charged where $0.22 / $0.66 applies, on roughly 14 of the 70 peak-window hours in a week.

There is a second, subtler half. DeepSeek counts the weekday on **its own clock** (Beijing, UTC+8), not on UTC. Worth stating plainly: with the windows as they stand today (01–04 and 06–10 UTC) that distinction never changes a bill, because the UTC and Beijing dates only disagree from 16:00 UTC onward and both windows sit before it. It starts mattering the day a window moves past 16:00 UTC — which is exactly the kind of change that would land silently, since no test written against the real windows can see it. Hence the synthetic 15:00–20:00 card in the tests.

## What changed

- `ModelPricingSchedule` gains optional `peakDaysIso` (1 = Monday … 7 = Sunday) and `peakDaysUtcOffset` (the clock the day is counted on). Hours stay declared and read in UTC; only the calendar date shifts.
- `DEEPSEEK_PRICING_SCHEDULE` sets `[1,2,3,4,5]` and `8`.
- **Both** copies of the check are fixed: `src/renderer/src/lib/model-pricing.ts` and the private one in `cli/src/runtime/open-cowork-worker-runtime.ts`. They'd otherwise quote different prices for the same request — the CLI copy re-validates every field because its schedule arrives as persisted JSON.
- A schedule with no `peakDaysIso` behaves exactly as today, so nothing but DeepSeek changes.
- An unreadable day list drops the restriction **whole**, not entry by entry. Filtering `[1,2,3,4,5,'6']` down to `[1..5]` would look like a clean weekday rule and quietly discount the Saturday the card meant to charge for; dropping the lot only ever charges the rate already charged today. Same for a bad offset — it falls back to reading the day in UTC.

## Testing

`scripts/test/model-pricing-tiers.test.ts` — 7 new cases: the weekend is off-peak inside a window, a schedule without peak days is unrestricted, the day is read on the vendor clock (15:59Z Friday peak → 16:00Z off-peak, 15:59Z Sunday off-peak → 16:00Z peak), days without an offset are counted in UTC, twelve shapes of unreadable day list all bill peak, five shapes of unreadable offset fall back to UTC, and one end-to-end `resolveModelPrices` check on the real DeepSeek card.

```
node --test scripts/test/model-pricing-tiers.test.ts   →  14 pass, 0 fail
```

Mutation-checked, since a pricing test that can't fail is worse than none:

| mutation | result |
| --- | --- |
| drop the day condition from the peak branch | 5 fail |
| ignore the offset, count the day in UTC | 1 fail (the vendor-clock test, and only that one) |
| filter bad day entries instead of dropping the list | 1 fail (the malformed-list test) |

The CLI worker runtime has no test harness in-repo, so I ran its copy of the four functions standalone against the same 14 instants and confirmed it answers identically to the renderer copy.

What I could **not** run here: `npm run typecheck` and `npm run lint` — no `node_modules` in this environment. The new code is plain TS with no new imports and stays inside the 100-column / no-semicolon style, but the type check is worth a look on your side before merging.

## Note on the UI

`formatPeakHoursUtc` still prints only the hour windows, so the settings hint reads "Peak hours (UTC): 01:00–04:00, 06:00–10:00" with no mention of weekdays. I left it alone deliberately — `provider.peakHoursHint` exists in 17 locale files and the zh string already spells out the Beijing hours, so getting that wording right across all of them is a separate change and yours to make, not something to bury in a billing fix.
